### PR TITLE
Oereb annex update

### DIFF
--- a/oereb_annex/build.gradle
+++ b/oereb_annex/build.gradle
@@ -6,84 +6,55 @@ import de.undercouch.gradle.tasks.download.Download
 apply plugin: "ch.so.agi.gretl"
 apply plugin: "de.undercouch.download"
 
-defaultTasks "importOEREBAnnex"
+defaultTasks "transferStageToLive"
 
-def GROUP = "oereb-annex_import"
-def dbSchemas = ["stage","live"]
+def GROUP = "oereb-annex_data-transfer"
 def pathToTempFolder = System.getProperty("java.io.tmpdir")
+def annexModel = "OeREB_ExtractAnnex_V1_0"
+def xtfFile = "ch.so.agi.OeREB_extractAnnex.xtf"
 
-task "downloadAnnexAktiveGemeinden"(type: Download){
-    description = "Download Annex Data Aktive Gemeinden"
+task "updateAVImportDate"(type: SqlExecutor){
+    description = "Update des AV-Import Datums per Gemeinde"
     group = GROUP
-    src "https://geo.so.ch/geodata/ch.so.agi.extractannex.oereb/ch.so.agi.OeREB_extractAnnex-AktiveGemeinden.xtf"
-    dest pathToTempFolder
-    overwrite true
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    sqlFiles = ["update_avimportdate_in_annex_model.sql"]
 }
 
-task "downloadAnnexKatasterAmt"(type: Download, dependsOn: "downloadAnnexAktiveGemeinden"){
-    description = "Download Annex Data Katasteramt"
+//OEREB-Annex-Export
+task "exportAnnexData"(type: Ili2pgExport, dependsOn: "updateAVImportDate") {
+    description = "Export of the OEREB Annex Data from editdb into INTERLIS-File $xtfFile"
     group = GROUP
-    src "https://geo.so.ch/geodata/ch.so.agi.extractannex.oereb/ch.so.agi.OeREB_extractAnnex-KatatasterAmt.xtf"
-    dest pathToTempFolder
-    overwrite true
+    database = [dbUriEdit, dbUserEdit, dbPwdEdit]
+    models = annexModel
+    dbschema = "agi_oereb_annex"
+    dataFile = "$rootDir/" + "$xtfFile"
+    disableValidation = false
 }
 
-task "downloadAnnexStammdaten"(type: Download, dependsOn: "downloadAnnexKatasterAmt"){
-    description = "Download Annex Stammdaten"
+task "importAnnexDataStage"(type: Ili2pgReplace, dependsOn: "exportAnnexData"){
+    description = "Import Annex Data into Schema stage with dataset $xtfFile"
     group = GROUP
-    src "https://geo.so.ch/geodata/ch.so.agi.extractannex.oereb/ch.so.agi.OeREB_extractAnnex-Stammdaten.xtf"
-    dest pathToTempFolder
-    overwrite true
+    database = [dbUriOereb, dbUserOereb, dbPwdOereb]
+    dataset = "ch.so.agi.OeREB_extractAnnex_stage"
+    models = annexModel
+    dbschema = "stage"
+    dataFile = "$rootDir/" + "$xtfFile"
+    disableValidation = false
 }
 
-//OEREB-Annex-import
-dbSchemas.each { dbSchema ->
-
-    task "importAnnexAktiveGemeinden_$dbSchema"(type: Ili2pgReplace, dependsOn: "downloadAnnexStammdaten"){
-        description = "Import Annex Data Aktive Gemeinden"
-        group = GROUP
-        database = [dbUriOereb, dbUserOereb, dbPwdOereb]
-        models = "OeREB_ExtractAnnex_V1_0"
-        dbschema = "$dbSchema"
-        dataFile = file(Paths.get(pathToTempFolder.toString(), "ch.so.agi.OeREB_extractAnnex-AktiveGemeinden.xtf"))
-        dataset = "ch.so.agi.oereb_extract_annex.aktive_gemeinden"
-        disableValidation = true
-    }
-
-
-    task "importAnnexKatasteramt_$dbSchema"(type: Ili2pgReplace, dependsOn: "importAnnexAktiveGemeinden_$dbSchema"){
-        description = "Import Annex Data Katasteramt"
-        group = GROUP
-        database = [dbUriOereb, dbUserOereb, dbPwdOereb]
-        models = "OeREB_ExtractAnnex_V1_0"
-        dbschema = "$dbSchema"
-        dataFile = file(Paths.get(pathToTempFolder.toString(), "ch.so.agi.OeREB_extractAnnex-KatatasterAmt.xtf"))
-        dataset = "ch.so.agi.oereb_extract_annex.katasteramt"
-        disableValidation = true
-    }
-
-    task "importAnnexStammdaten_$dbSchema"(type: Ili2pgReplace, dependsOn: "importAnnexKatasteramt_$dbSchema"){
-        description = "Import Annex Stammdaten"
-        group = GROUP
-        database = [dbUriOereb, dbUserOereb, dbPwdOereb]
-        models = "OeREB_ExtractAnnex_V1_0"
-        dbschema = "$dbSchema"
-        dataFile = file(Paths.get(pathToTempFolder.toString(), "ch.so.agi.OeREB_extractAnnex-Stammdaten.xtf"))
-        dataset = "ch.so.agi.oereb_extract_annex.stammdaten"
-        disableValidation = true
-    }
-}
-
-// this task is the main task to be started
-task importOEREBAnnex() {
-    description = "Aggregationstask."
+task "syncDatasetsAndBaskets"(type: SqlExecutor, dependsOn: "importAnnexDataStage"){
+    description = "Synchronization of dataset and basket tables"
     group = GROUP
-    doLast {
-        println "ÖREB annex data imported."
-    }
+    database = [dbUriOereb, dbUserOereb, dbPwdOereb]
+    sqlFiles = ["synchronize_dataset_and_baskets_stage-live.sql"]
 }
 
-// finds all tasks from the each loop and sets them as dependants
-importOEREBAnnex.dependsOn {
-    tasks.findAll { task -> task.name.startsWith('importAnnexStammdaten_') }
+task "transferStageToLive"(type: SqlExecutor, dependsOn: "syncDatasetsAndBaskets"){
+    description = "Transfer of OEREB annex tables stage to live schema without theme codelist"
+    group = GROUP
+    database = [dbUriOereb, dbUserOereb, dbPwdOereb]
+    sqlFiles = ["transferStageToLive.sql"]
 }
+
+
+

--- a/oereb_annex/job.properties
+++ b/oereb_annex/job.properties
@@ -1,0 +1,1 @@
+triggers.cron=H H(1-3) * * *

--- a/oereb_annex/synchronize_dataset_and_baskets_stage-live.sql
+++ b/oereb_annex/synchronize_dataset_and_baskets_stage-live.sql
@@ -1,0 +1,9 @@
+-- datasets
+INSERT INTO live.t_ili2db_dataset
+SELECT t_id, datasetname FROM stage.t_ili2db_dataset 
+  WHERE t_id NOT IN (SELECT t_id FROM live.t_ili2db_dataset);
+-- baskets
+INSERT INTO live.t_ili2db_basket
+SELECT t_id, dataset, topic, t_ili_tid, attachmentkey, domains
+  FROM stage.t_ili2db_basket
+ WHERE t_id NOT IN (SELECT t_id FROM live.t_ili2db_basket)

--- a/oereb_annex/transferStageToLive.sql
+++ b/oereb_annex/transferStageToLive.sql
@@ -1,0 +1,45 @@
+--first delete everything in the right order
+DELETE FROM live.oerb_xtnx_v1_0annex_logo;
+DELETE FROM live.oerb_xtnx_v1_0annex_glossary;
+DELETE FROM live.oerb_xtnx_v1_0annex_exclusionofliability;
+DELETE FROM live.oerb_xtnx_v1_0annex_generalinformation;
+DELETE FROM live.oerb_xtnx_v1_0annex_thematxt;
+DELETE FROM live.oereb_extractannex_v1_0_code_;
+DELETE FROM live.oerb_xtnx_v1_0annex_municipalitywithplrc;
+DELETE FROM live.oerb_xtnx_v1_0annex_office;
+DELETE FROM live.oerb_xtnx_v1_0annex_maplayering;
+DELETE FROM live.oerb_xtnx_v1_0annex_basedata;
+
+-- base data
+INSERT INTO live.oerb_xtnx_v1_0annex_basedata
+ SELECT * FROM stage.oerb_xtnx_v1_0annex_basedata;
+-- map layering
+INSERT INTO live.oerb_xtnx_v1_0annex_maplayering
+ SELECT * FROM stage.oerb_xtnx_v1_0annex_maplayering;
+-- office
+INSERT INTO live.oerb_xtnx_v1_0annex_office
+ SELECT * FROM stage.oerb_xtnx_v1_0annex_office;
+-- municipality with plrc
+INSERT INTO live.oerb_xtnx_v1_0annex_municipalitywithplrc
+  SELECT * FROM stage.oerb_xtnx_v1_0annex_municipalitywithplrc;
+-- code list for active themes in muncipalities
+INSERT INTO live.oereb_extractannex_v1_0_code_
+  SELECT code.* FROM stage.oereb_extractannex_v1_0_code_ code
+      LEFT JOIN stage.t_ili2db_basket basket ON code.t_basket = basket.t_id
+      LEFT JOIN stage.t_ili2db_dataset dataset ON basket.dataset = dataset.t_id
+    WHERE dataset.datasetname = 'ch.so.agi.OeREB_extractAnnex_live';
+-- themes - thematxt
+INSERT INTO live.oerb_xtnx_v1_0annex_thematxt
+ SELECT * FROM stage.oerb_xtnx_v1_0annex_thematxt;
+-- generalinformation
+INSERT INTO live.oerb_xtnx_v1_0annex_generalinformation 
+ SELECT * FROM stage.oerb_xtnx_v1_0annex_generalinformation;
+-- exclusion of liability
+INSERT INTO live.oerb_xtnx_v1_0annex_exclusionofliability
+ SELECT * FROM stage.oerb_xtnx_v1_0annex_exclusionofliability;
+-- glossary
+INSERT INTO live.oerb_xtnx_v1_0annex_glossary
+  SELECT * FROM stage.oerb_xtnx_v1_0annex_glossary;
+-- logo
+INSERT INTO live.oerb_xtnx_v1_0annex_logo
+  SELECT * FROM stage.oerb_xtnx_v1_0annex_logo;

--- a/oereb_annex/update_avimportdate_in_annex_model.sql
+++ b/oereb_annex/update_avimportdate_in_annex_model.sql
@@ -1,0 +1,15 @@
+WITH av_updates AS (
+    SELECT
+       ds.datasetname::int4 AS bfsnr,
+       max(imp.importdate) AS last_importdate
+    FROM agi_dm01avso24.t_ili2db_dataset ds
+      LEFT JOIN agi_dm01avso24.t_ili2db_import imp ON ds.t_id = imp.dataset
+      GROUP BY ds.datasetname, imp.dataset
+      ORDER BY ds.datasetname ASC
+)
+UPDATE
+  agi_oereb_annex.oerb_xtnx_v1_0annex_municipalitywithplrc munip
+    SET basedatadate=avupd.last_importdate
+  FROM av_updates avupd
+    WHERE munip.municipality = avupd.bfsnr
+;


### PR DESCRIPTION
PR für die Aktualisierung von ÖREB-Annexdaten.

Im gradle-File laufen folgende Schritte ab:

1. Abgleich in edit-db des last_importdate in agi_oereb_annex.oerb_xtnx_v1_0annex_municipalitywithplrc aus   AV-Importdaten von agi_dm01avso24.t_ili2db_import 
2. Export der Annex-Daten in ITF-Datei aus editdb
3. Import der Annex-Daten aus ITF-Datei in oereb-db schema stage
4. In oereb-DB: Synchronisation von baskets und datasets von stage zu live
5. Abgleich aller Annex-Daten von stage zu live die das datasetname 'ch.so.agi.OeREB_extractAnnex_live' haben

TODO: Export-File archivieren?