### PR TITLE
[oereb_nutzungsplanung] more geometry cleaning...

### DIFF
--- a/oereb_nutzungsplanung/insert_oereb_landuseplans_tables.sql
+++ b/oereb_nutzungsplanung/insert_oereb_landuseplans_tables.sql
@@ -1194,7 +1194,8 @@ INSERT INTO
         nutzung.t_id,
         basket_dataset.basket_t_id AS t_basket,
         basket_dataset.datasetname AS t_datasetname,
-        ST_MakeValid(ST_RemoveRepeatedPoints(ST_SnapToGrid(nutzung.geometrie, 0.001))) AS flaeche_lv95,
+        --ST_MakeValid(ST_RemoveRepeatedPoints(ST_SnapToGrid(nutzung.geometrie, 0.001))) AS flaeche_lv95,
+        ST_GeometryN(ST_CollectionExtract(ST_MakeValid(ST_RemoveRepeatedPoints(ST_SnapToGrid(nutzung.geometrie, 0.001))), 3), 1) AS flaeche_lv95,
         nutzung.rechtsstatus AS rechtsstatus,
         nutzung.publiziertab AS publiziertab,
         eigentumsbeschraenkung.t_id AS eigentumsbeschraenkung,
@@ -1226,6 +1227,8 @@ INSERT INTO
             arp_npl.nutzungsplanung_ueberlagernd_flaeche
         WHERE
             rechtsstatus = 'inKraft'
+        AND
+            ST_IsEmpty(geometrie) IS FALSE
     ) AS nutzung
     INNER JOIN arp_npl_oereb.transferstruktur_eigentumsbeschraenkung AS eigentumsbeschraenkung
     ON nutzung.typ_nutzung = eigentumsbeschraenkung.t_id,


### PR DESCRIPTION
Kommentar aus E-Mail:

Also, leider unschöne Geschichte:

Wie man bei der Prüfung mit ilivalidator ("enhanced": https://geo-t.so.ch/ilivalidator oder https://geo.so.ch/ilivalidator-nplso ) sieht, hat z.B. Kestenholz viele Fehler. Vor allem auch diese doppelten Koordinaten und Überlappungen. Aus diesem Grund mache ich - sehr zu meinem Leidwesen - furchtbare Turnübungen wie:

ST_MakeValid(ST_RemoveRepeatedPoints(ST_SnapToGrid(nutzung.geometrie, 0.001))) AS flaeche_lv95

Das führt in Kestenholz jedoch jetzt zu einem Multipolygon (das aber nur aus einem Polygon besteht) und zwei GeometryCollections. PostGIS bietet gute Funktionen (ST_Dump und so), um diese Konstrukte auseinander zu nehmen und zu Polygonen zu machen. Das würde aber dazu führen, dass man die Original-TID verlieren würde. Weil aus einem Objekt zwei Objekte werden. Ob ich das zulassen kann, weiss ich nicht ohne es gross zu testen. Was ich jetzt mache:

1) (Multi)Polygone aus der GeometryCollection extrahieren. Alles andere in der GeometryCollection ignoriere ich.
2) Die erste Geometrie aus den MultiPolygonen verwenden.

Das sieht dann so aus:

ST_GeometryN(ST_CollectionExtract(ST_MakeValid(ST_RemoveRepeatedPoints(ST_SnapToGrid(nutzung.geometrie, 0.001))), 3), 1) AS flaeche_lv95

Zudem gibt es in Kestenholz Polygone (bei den überlagernden Flächen) mit Fläche 0 und ST_IsEmpty(geom)=TRUE. Das kann man bereits in QGIS im "arp_npl"-Schema beobachten. Diese filtere ich mit:

ST_IsEmpty(geometrie) IS FALSE

Der "transferData"-Task läuft bei mir lokal mit Kestenholz und Oensingen durch. Exportiert und geprüft habe ich aber nichts. Ebenso noch nichts in Repo committed.

Gebastel wegen unsauberen Daten halt... 

Stefan
