### PR TITLE
Use gretl command instead of gradle with options

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                 script { currentBuild.description = "${params.buildDescription}" }
                 git url: "${gretlJobRepoUrl}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle importDataToStage refreshOerebWMSTablesStage"
+                    sh 'gretl importDataToStage refreshOerebWMSTablesStage'
                     zip zipFile: 'xtfdata.zip', glob: '*.xtf', archive: true
                 }
                 stash name: "gretljob"
@@ -40,7 +40,7 @@ pipeline {
             steps {
                 unstash name: "gretljob"
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle importDataToLive refreshOerebWMSTablesLive"
+                    sh 'gretl importDataToLive refreshOerebWMSTablesLive'
                 }
             }
         }

--- a/oereb_annex/Jenkinsfile
+++ b/oereb_annex/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_av/Jenkinsfile
+++ b/oereb_av/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_bundescodelisten/Jenkinsfile
+++ b/oereb_bundescodelisten/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_bundesdaten/Jenkinsfile
+++ b/oereb_bundesdaten/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_bundesgesetze/Jenkinsfile
+++ b/oereb_bundesgesetze/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_gbkreise/Jenkinsfile
+++ b/oereb_gbkreise/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_kantonale_gesetze/Jenkinsfile
+++ b/oereb_kantonale_gesetze/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }

--- a/oereb_plzo/Jenkinsfile
+++ b/oereb_plzo/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
             steps {
                 git url: "${gretlJobsRepoUrlOereb}", branch: "${params.BRANCH ?: 'master'}", changelog: false
                 dir(env.JOB_BASE_NAME) {
-                    sh "gradle --init-script /home/gradle/init.gradle"
+                    sh 'gretl'
                 }
             }
         }


### PR DESCRIPTION
Es soll überall der Befehl `gretl` eingesetzt werden. So kann zentral beim GRETL Runtime Image in gesteuert werden, welche Optionen verwendet werden sollen: https://github.com/sogis/gretl/blob/86bb40e23bdc3ea79b4ec09896eeb3f4c80725b9/runtimeImage/gretl/gretl#L9