### PR TITLE
Use default name for docker network

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,5 @@ Start the GRETL job
 (use the --job-directory option to point to the desired GRETL job;
 find out the names of your Docker networks by running `docker network ls`):
 ```
-./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network oereb-gretljobs_oerebgretljobs --job-directory $PWD/oereb_nutzungsplanung/ importDataToStage refreshOerebWMSTablesStage
+./start-gretl.sh --docker-image sogis/gretl-runtime:latest --docker-network oereb-gretljobs_default --job-directory $PWD/oereb_nutzungsplanung/ importDataToStage refreshOerebWMSTablesStage
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and import demo data into the "edit" DB
 `createSchemaLandUsePlans replaceDataLandUsePlans`
 with the Gradle task names that handle your current OEREB topic):
 ```
-# docker-compose down # (optional; for cleaning up any already existing DB containers)
+docker-compose down # (this command is optional; it's just for cleaning up any already existing DB containers)
 docker-compose run --rm --user $UID -v $PWD/development_dbs:/home/gradle/project gretl "sleep 20 && cd /home/gradle && gretl -b project/build-dev.gradle importFederalLegalBasisToOereb importCantonalLegalBasisToOereb createSchemaLandUsePlans replaceDataLandUsePlans"
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       ORG_GRADLE_PROJECT_dbUriOereb: "jdbc:postgresql://oereb-db/oereb"
       ORG_GRADLE_PROJECT_dbUserOereb: gretl
       ORG_GRADLE_PROJECT_dbPwdOereb: gretl
-    networks:
-      - oerebgretljobs
     depends_on:
       - oereb-db
       - edit-db
@@ -35,8 +33,6 @@ services:
       PG_READ_PASSWORD: ogc_server
     ports:
       - "54321:5432"
-    networks:
-      - oerebgretljobs
     volumes:
       - ${PWD}/development_dbs/override_setupsql.sh:/tmp/override_setupsql.sh
   oereb-db:
@@ -57,8 +53,3 @@ services:
       PG_READ_PASSWORD: ogc_server
     ports:
       - "54322:5432"
-    networks:
-      - oerebgretljobs
-
-networks:
-  oerebgretljobs:


### PR DESCRIPTION
Don't set a name for the docker network. So the name will be `oereb-gretljobs_default` (at least on Linux), which is less confusing than `oereb-gretljobs_oerebgretljobs`. 