### PR TITLE
Add nodeLabel property

### DIFF
--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -103,6 +103,11 @@ for (jobFile in jobFiles) {
         cron(properties.getProperty('triggers.cron'))
       }
     }
+    if (properties.getProperty('nodeLabel') != null) {
+      parameters {
+        choiceParam('nodeLabel', [properties.getProperty('nodeLabel')], 'Label of the node that must run the job')
+      }
+    }
     definition {
       cps {
         script(pipelineScript)


### PR DESCRIPTION
Add nodeLabel property, even if it's not used in the Jenkinsfile. This is to keep the _gretl_job_generator.groovy_ file in sync with the one in the https://github.com/sogis/gretljobs repo.