### PR TITLE
Möglichkeit, alle Builds aufzubewahren

### DIFF
--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -90,8 +90,10 @@ for (jobFile in jobFiles) {
     authorization {
       permissions(properties.getProperty('authorization.permissions'), ['hudson.model.Item.Build', 'hudson.model.Item.Read'])
     }
-    logRotator {
-      numToKeep(properties.getProperty('logRotator.numToKeep') as Integer)
+    if (properties.getProperty('logRotator.numToKeep') != 'unlimited') {
+      logRotator {
+        numToKeep(properties.getProperty('logRotator.numToKeep') as Integer)
+      }
     }
     if (properties.getProperty('triggers.upstream') != 'none') {
       triggers {

--- a/oereb_belastete_standorte/job.properties
+++ b/oereb_belastete_standorte/job.properties
@@ -1,2 +1,3 @@
 parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
 authorization.permissions=gretl-users-bdafu
+logRotator.numToKeep=unlimited

--- a/oereb_grundwasserschutz/job.properties
+++ b/oereb_grundwasserschutz/job.properties
@@ -1,2 +1,3 @@
 parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
 authorization.permissions=gretl-users-bdafu
+logRotator.numToKeep=unlimited

--- a/oereb_nutzungsplanung/job.properties
+++ b/oereb_nutzungsplanung/job.properties
@@ -1,2 +1,3 @@
 parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
 authorization.permissions=gretl-users-barpa
+logRotator.numToKeep=unlimited

--- a/oereb_waldgrenzen/job.properties
+++ b/oereb_waldgrenzen/job.properties
@@ -1,2 +1,3 @@
 parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
 authorization.permissions=gretl-users-vkfaa
+logRotator.numToKeep=unlimited


### PR DESCRIPTION
Wenn man in job.properties `logRotator.numToKeep=unlimited` setzt, werden alle Builds aufbewahrt. Wenn man nichts setzt, werden weiterhin standardmässig die letzten 15 Builds aufbewahrt. Oder es kann weiterhin ein beliebiert Zahlenwert gesetzt werden.

Achtung: Jobs, die bereits zuvor generiert worden sind und bei denen diese Einstellung auf einen bestimmten Wert gesetzt war, behalten auch beim Umstellen auf `logRotator.numToKeep=unlimited` diesen Wert. D.h. bei diesen Jobs muss einmalig die Option "Alte Builds verwefen" manuell ausgeschaltet werden.

Resolves #85 