### PR TITLE
Switch job.properties to UTF-8

### DIFF
--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -63,7 +63,7 @@ for (jobFile in jobFiles) {
   def propertiesFile = new File(baseDir, propertiesFilePath)
   if (propertiesFile.exists()) {
     println 'properties file found: ' + propertiesFilePath
-    properties.load(propertiesFile.newDataInputStream())
+    properties.load(new FileReader(propertiesFile))
   }
   
   def productionEnv = ("${OPENSHIFT_BUILD_NAMESPACE}" == 'agi-gretl-production')

--- a/oereb_belastete_standorte/job.properties
+++ b/oereb_belastete_standorte/job.properties
@@ -1,3 +1,3 @@
-parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
+parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund fÃ¼r die Publikation der Daten
 authorization.permissions=gretl-users-bdafu
 logRotator.numToKeep=unlimited

--- a/oereb_einzelschutz_denkmal/job.properties
+++ b/oereb_einzelschutz_denkmal/job.properties
@@ -1,3 +1,3 @@
-parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
+parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund fÃ¼r die Publikation der Daten
 authorization.permissions=gretl-users-edden
 logRotator.numToKeep=unlimited

--- a/oereb_gewaesserschutz/job.properties
+++ b/oereb_gewaesserschutz/job.properties
@@ -1,3 +1,3 @@
-parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
+parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund fÃ¼r die Publikation der Daten
 authorization.permissions=gretl-users-bdafu
 logRotator.numToKeep=unlimited

--- a/oereb_nutzungsplanung/job.properties
+++ b/oereb_nutzungsplanung/job.properties
@@ -1,3 +1,3 @@
-parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
+parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund fÃ¼r die Publikation der Daten
 authorization.permissions=gretl-users-barpa
 logRotator.numToKeep=unlimited

--- a/oereb_waldgrenzen/job.properties
+++ b/oereb_waldgrenzen/job.properties
@@ -1,3 +1,3 @@
-parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten
+parameters.stringParam:buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund fÃ¼r die Publikation der Daten
 authorization.permissions=gretl-users-vkfaa
 logRotator.numToKeep=unlimited


### PR DESCRIPTION
By using the `load(Reader)` instead of the `load(InputStream)` method, the `job.properties` files don't need to be ISO 8859-1 encoded. As documented on https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html.