### PR TITLE
Disable concurrent builds globally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -54,6 +54,9 @@ for (jobFile in jobFiles) {
   def productionEnv = ("${PROJECT_NAME}" == 'agi-gretl-production')
 
   pipelineJob(jobName) {
+    properties {
+      disableConcurrentBuilds {}
+    }
     if (!productionEnv) { // we don't want the BRANCH parameter in production environment
       parameters {
         stringParam('BRANCH', 'main', 'Name of branch to check out')

--- a/oerebv2_nutzungsplanung/Jenkinsfile
+++ b/oerebv2_nutzungsplanung/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
     agent none
     options {
-        disableConcurrentBuilds()
         timeout(time: 7, unit: 'DAYS')
     }
     stages {


### PR DESCRIPTION
Instead of disabling concurrent builds using the Jenkinsfile/Jenkinsfiles, disable it globally by defining the `disableConcurrentBuilds` property when _gretl_job_generator.groovy_ generates the job.