### PR TITLE
Provide node label as env var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
     stages {
         stage('Import into staging schema') {
-            agent { label 'gretl' }
+            agent { label env.NODE_LABEL ?: 'gretl' }
             steps {
                 script { currentBuild.description = "${params.buildDescription}" }
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
@@ -30,7 +30,7 @@ pipeline {
             }
         }
         stage('Import into live schema') {
-            agent { label 'gretl' }
+            agent { label env.NODE_LABEL ?: 'gretl' }
             steps {
                 unstash name: "gretljob"
                 container('gretl') {

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -116,17 +116,16 @@ for (jobFile in jobFiles) {
         }
       }
     }
-    if (jobProperties.getProperty('nodeLabel') != null) {
-      parameters {
-        choiceParam('nodeLabel', [jobProperties.getProperty('nodeLabel')], 'Label of the node that must run the job')
-      }
-    }
 
     environmentVariables {
       // make the Git repository URL available on the Jenkins agent
       env('GIT_REPO_URL', GRETL_JOB_REPO_URL_OEREB_V2)
       // make the OpenShift project name available on the Jenkins agent
       env('OPENSHIFT_PROJECT_NAME', PROJECT_NAME)
+      // if nodeLabel property is set, make it available on the Jenkins agent
+      if (jobProperties.getProperty('nodeLabel') != null) {
+        env('NODE_LABEL', jobProperties.getProperty('nodeLabel'))
+      }
     }
 
     definition {

--- a/gretl_job_generator.groovy
+++ b/gretl_job_generator.groovy
@@ -39,7 +39,7 @@ for (jobFile in jobFiles) {
   def jobProperties = new Properties([
     'authorization.permissions':'nobody',
     'logRotator.numToKeep':'unlimited',
-    'parameters.fileParam':'none',
+    'parameters.stashedFile':'none',
     'parameters.stringParams':'buildDescription;Keine Beschreibung angegeben;Beschreibung/Grund für die Publikation der Daten',
     'triggers.upstream':'none',
     'triggers.cron':''
@@ -62,9 +62,13 @@ for (jobFile in jobFiles) {
         stringParam('BRANCH', 'main', 'Name of branch to check out')
       }
     }
-    if (jobProperties.getProperty('parameters.fileParam') != 'none') {
+    if (jobProperties.getProperty('parameters.stashedFile') != 'none') {
       parameters {
-        fileParam(jobProperties.getProperty('parameters.fileParam'), 'Select file to upload')
+        // must be defined using the "Dynamic DSL" approach (https://github.com/jenkinsci/job-dsl-plugin/wiki/Dynamic-DSL):
+        stashedFile {
+          name(jobProperties.getProperty('parameters.stashedFile'))
+          description('Hochzuladende Datei auswählen')
+        }
       }
     }
     if (jobProperties.getProperty('parameters.stringParams') != 'none') {

--- a/oerebv2_av/Jenkinsfile
+++ b/oerebv2_av/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_bundesdaten/Jenkinsfile
+++ b/oerebv2_bundesdaten/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_bundesgesetze/Jenkinsfile
+++ b/oerebv2_bundesgesetze/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_bundeskonfiguration/Jenkinsfile
+++ b/oerebv2_bundeskonfiguration/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_gesetze/Jenkinsfile
+++ b/oerebv2_konfiguration_gesetze/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_grundbuchkreis/Jenkinsfile
+++ b/oerebv2_konfiguration_grundbuchkreis/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_logo/Jenkinsfile
+++ b/oerebv2_konfiguration_logo/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_text/Jenkinsfile
+++ b/oerebv2_konfiguration_text/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_themen/Jenkinsfile
+++ b/oerebv2_konfiguration_themen/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_verfuegbarkeit/Jenkinsfile
+++ b/oerebv2_konfiguration_verfuegbarkeit/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_konfiguration_zustaendigestellen/Jenkinsfile
+++ b/oerebv2_konfiguration_zustaendigestellen/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_nutzungsplanung/Jenkinsfile
+++ b/oerebv2_nutzungsplanung/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     }
     stages {
         stage('Import into staging schema') {
-            agent { label 'gretl' }
+            agent { label env.NODE_LABEL ?: 'gretl' }
             steps {
                 script { currentBuild.description = "${params.buildDescription}" }
                 git url: "${env.GIT_REPO_URL}", branch: "${params.BRANCH ?: 'main'}", changelog: false
@@ -30,7 +30,7 @@ pipeline {
             }
         }
         stage('Import into live schema') {
-            agent { label 'gretl' }
+            agent { label env.NODE_LABEL ?: 'gretl' }
             steps {
                 unstash name: "gretljob"
                 container('gretl') {

--- a/oerebv2_nutzungsplanung_migration/Jenkinsfile
+++ b/oerebv2_nutzungsplanung_migration/Jenkinsfile
@@ -23,7 +23,7 @@ node('master') {
 
 // Declarative pipeline starts here
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {

--- a/oerebv2_plzo/Jenkinsfile
+++ b/oerebv2_plzo/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent { label 'gretl' }
+    agent { label env.NODE_LABEL ?: 'gretl' }
     stages {
         stage('GRETL job') {
             options {


### PR DESCRIPTION
And enable jobs to run on a specific agent if required.

Furthermore switch to _stashedFile_ parameter, even if it's not used in this type of job. The aim is to keep the GRETL Job generator scripts in sync as much as possible.