### PR TITLE
[einzelschutz_denkmal] Remove modeldir

### DIFF
--- a/oerebv2_einzelschutz_denkmal/build.gradle
+++ b/oerebv2_einzelschutz_denkmal/build.gradle
@@ -15,7 +15,6 @@ def iliModelTransferstruktur = "OeREBKRMtrsfr_V2_0"
 def iliModelSymbole = "SO_AGI_OeREB_Legendeneintraege_20211020"
 
 def dbSchemaEinzelschutzDenkmalOereb = "ada_denkmalschutz_oerebv2"
-def interlisModelDir = "https://models.interlis.ch/;https://models.geo.admin.ch/;%ILI_FROM_DB"
 
 def einzelschutzDenkmalDataSet = "ch.so.ada.oereb_einzelschutz_denkmal"
 def symbolsDenkmalFlaecheDataSet = einzelschutzDenkmalDataSet + "_flaeche.symbole" 
@@ -60,7 +59,6 @@ task importResponsibleOfficesToOereb(type: Ili2pgReplace, dependsOn: 'downloadRe
     description = "Import zuständige Stellen ($responsibleOfficesDataSet)."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelBasis
-    modeldir = interlisModelDir
     dbschema = dbSchemaEinzelschutzDenkmalOereb
     dataFile = file(Paths.get(pathToTempFolder.toString(), responsibleOfficesDataSet + ".xtf"))
     importBid = true
@@ -75,7 +73,6 @@ symbolsDataSets.each { symbolsDataSet ->
         dbschema = dbSchemaEinzelschutzDenkmalOereb
         dataset = symbols
         models = iliModelSymbole
-        modeldir = interlisModelDir
         dataFile = file(Paths.get("$rootDir", symbols + ".xtf"))
         disableValidation = true
         importBid = true
@@ -95,7 +92,6 @@ task importEmptyTransferToOereb(type: Ili2pgReplace, dependsOn: 'deleteFromOereb
     description = "Import eines leeren Grund-Basket damit notwendige Datasets- und Basketrecords für Transferdaten in der DB erstellt werden."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelTransferstruktur
-    modeldir = interlisModelDir
     dbschema = dbSchemaEinzelschutzDenkmalOereb
     dataFile = file(emptyTransferFile)
     importBid = true
@@ -112,7 +108,6 @@ task exportData(type: Ili2pgExport, dependsOn: "transferData") {
     description = "Exportiert die umgebauten Daten aus dem Transferschema in ein INTERLIS-Datei."
     database = [dbUriEdit, dbUserEdit, dbPwdEdit]
     models = iliModelTransferstruktur
-    modeldir = interlisModelDir
     dbschema = dbSchemaEinzelschutzDenkmalOereb
     dataFile = file(Paths.get("$rootDir", xtfFileName))
     dataset = einzelschutzDenkmalDataSet
@@ -144,7 +139,6 @@ task importDataToStage(type: Ili2pgReplace, dependsOn: "validateData") {
     description = "Import des Einzelschutz-ÖREB-Datensatz in das Stage-Schema."
     database = [dbUriOerebV2, dbUserOerebV2, dbPwdOerebV2]
     models = iliModelTransferstruktur 
-    modeldir = interlisModelDir
     dbschema = "stage"
     dataFile = file(Paths.get("$rootDir", xtfFileName))
     dataset = einzelschutzDenkmalDataSet
@@ -164,7 +158,6 @@ task importDataToLive(type: Ili2pgReplace, dependsOn: "refreshOerebWMSTablesStag
     description = "Import des Einzelschutz-ÖREB-Datensatz in das Live-Schema."
     database = [dbUriOerebV2, dbUserOerebV2, dbPwdOerebV2]
     models = iliModelTransferstruktur
-    modeldir = interlisModelDir
     dbschema = "live"
     dataFile = file(Paths.get("$rootDir", xtfFileName))
     dataset = einzelschutzDenkmalDataSet 


### PR DESCRIPTION
The `modeldir` option should not be necessary. Removing this option so the models are read from the DB schema instead.